### PR TITLE
Feature/jwt

### DIFF
--- a/backend/src/services/jwt.service.js
+++ b/backend/src/services/jwt.service.js
@@ -1,0 +1,72 @@
+import jwt from 'jsonwebtoken';
+import * as dotenv from 'dotenv';
+
+/**
+ * Servicio para la gestión de tokens JWT.
+ * Permite firmar y verificar tokens utilizando una clave secreta y expiración configurable.
+ */
+class JWT {
+
+    /**
+     * Inicializa el servicio JWT con la clave secreta y el tiempo de expiración.
+     * @constructor
+     */
+    constructor() {
+        dotenv.config();
+
+        /**
+         * Clave secreta utilizada para firmar y verificar los tokens.
+         * @type {string}
+         */
+        this.secret = process.env.JWT_SECRET;
+
+        /**
+         * Tiempo de expiración de los tokens (por defecto: '1h').
+         * @type {string}
+         */
+        this.expiration = '1h';
+    }
+
+    /**
+     * Firma un nuevo token JWT con el payload proporcionado.
+     * @param {Object} payload - Información a incluir en el token.
+     * @returns {string} El token JWT firmado.
+     * @example
+     * const jwtService = new JWT();
+     * const token = jwtService.sign({ userId: '123' });
+     */
+    sign(payload) {
+        const result = jwt.sign(payload, this.secret, { expiresIn: this.expiration });
+        return result;
+    }
+
+    /**
+     * Verifica la validez de un token JWT.
+     * @param {string} token - El token JWT a verificar.
+     * @returns {Object} Un objeto con la propiedad 'success' (boolean) y 'data' (payload decodificado o error).
+     * @example
+     * const jwtService = new JWT();
+     * const result = jwtService.verify(token);
+     * if (result.success) {
+     *   // Token válido, acceder a result.data
+     * } else {
+     *   // Token inválido, manejar error
+     * }
+     */
+    verify(token) {
+        try {
+            const decoded = jwt.verify(token, this.secret);
+            return {
+                success: true,
+                data: decoded
+            };
+        } catch (err) {
+            return {
+                success: false,
+                data: err.name
+            };
+        }
+    }
+}
+
+export default JWT;

--- a/backend/tests/jwt.service.test.js
+++ b/backend/tests/jwt.service.test.js
@@ -1,0 +1,30 @@
+import JWT from '../src/services/jwt.service.js';
+
+describe('JWT Service', () => {
+    let jwtService;
+    const payload = { userId: 'test123' };
+
+    beforeAll(() => {
+        process.env.SECRET_KEY = 'test_secret';
+        jwtService = new JWT();
+    });
+
+    test('sign() debe retornar un JWT valido', () => {
+        const token = jwtService.sign(payload);
+        expect(typeof token).toBe('string');
+        expect(token.split('.').length).toBe(3); // JWT has 3 parts
+    });
+    
+    test('verify() retorna un objeto con propiedad success verdadera para un token válido', () => {
+        const token = jwtService.sign(payload);
+        const result = jwtService.verify(token);
+        
+        expect(result).toHaveProperty('success', true);
+    });
+
+    test('verify() retorna un objeto con propiedad success false para un token no válido', () => {
+        const result = jwtService.verify('token-erroneo');
+        
+        expect(result).toHaveProperty('success', false);
+    });
+});


### PR DESCRIPTION
Cree un servicio para el manejor de los JWT en `src/services/jwt.service.js`
Cree un archivo separa de tests en `tests/jwt.service.test.js`

Esto se hizo con la finalidad de que se pueda usar conjuntamente el `jwt.service.js` con el `token.repository.js` conjuntamente a la hora de crear y guardar tokens en redis.

- [x]  Todos los **commits** en esta rama siguen el formato semántico.
- [x]  La funcionalidad fue **probada localmente** y funciona según lo esperado.
- [x]  He añadido o actualizado las **pruebas** necesarias para cubrir los cambios.
- [x]  Mi código **no introduce *Breaking Changes*** .

<img width="1180" height="297" alt="image" src="https://github.com/user-attachments/assets/201f63f3-ca4e-4412-a3d7-b37d0845e809" />
